### PR TITLE
Add Plausible Analytics tracking

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -103,6 +103,7 @@ const Head = ({ data }) => {
                 href={data.site.siteMetadata.icon}
                 type="image/png"
             />
+            <script defer data-domain="marquezproject.ai" src="https://plausible.io/js/script.outbound-links.js"></script>
             <link
                 href="https://fonts.googleapis.com/css2?family=Karla&amp;display=swap"
                 rel="stylesheet"


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross.turk@astronomer.io>

This implements Plausible Analytics as an alternative to GA. If this works out, we should disable GA in a future PR.