### PR TITLE
Update links to not be relative

### DIFF
--- a/contents/basepages/resources/index.mdx
+++ b/contents/basepages/resources/index.mdx
@@ -5,8 +5,8 @@ template: basepage
 
 ## Docs
 * [API Documentation](/openapi.html)
-* [Deployment Overview](deployment) 
-* [Running on AWS](running-on-aws) 
+* [Deployment Overview](/resources/deployment) 
+* [Running on AWS](/resources/running-on-aws) 
 
 ## Conference Talks
 


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@rossturk.com>

ON the new resources page, relative links (i.e. to `deployment`) work, but upon full build it seems that they need to be absolute (i.e. `/resources/deployment`).