### PR TITLE
[Docs] add Marquez color codes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ yarn
 yarn global add gatsby-cli
 gatsby develop
 ```
+
+Marquez green:
+RGB: 113-221-191
+CMYK: 49-0-14-13
+HEX: #71DDBF


### PR DESCRIPTION
For convenience, this change would add RGB, CMYK, and HEX codes for "Marquez green" to the README.

Signed-off-by: Michael Robinson <merobi@gmail.com>