### PR TITLE
correct dates on soft delete and column lineage posts

### DIFF
--- a/contents/blog/column-lineage-demo/index.mdx
+++ b/contents/blog/column-lineage-demo/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trying Out the New Column Lineage Feature
-date: 2022-10-18
+date: 2022-10-25
 author: Pawel Leszczynski & Michael Robinson
 image: ./image.svg
 banner: ./banner.svg

--- a/contents/blog/soft-delete/index.mdx
+++ b/contents/blog/soft-delete/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using the New Soft-delete Feature
-date: 2022-10-17
+date: 2022-10-25
 author: Maciej Obuchowski & Michael Robinson
 image: ./image.svg
 banner: ./banner.svg


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

After merging the posts, I noticed that the dates were incorrect. This change corrects the pub dates. 