### PR TITLE
fix soft delete post art dimensions

### DIFF
--- a/contents/blog/soft-delete/image.svg
+++ b/contents/blog/soft-delete/image.svg
@@ -1,4 +1,4 @@
-<svg width="600.24" height="270.25" xmlns="http://www.w3.org/2000/svg">
+<svg width="660" height="270" xmlns="http://www.w3.org/2000/svg">
 
  <g>
   <title>Layer 1</title>


### PR DESCRIPTION
The dimensions of the soft delete post artwork were slightly off. This change modifies the svg tag in `image.svg` to make all the art match.

Signed-off-by: Michael Robinson <merobi@gmail.com>