### PR TITLE
make small style edits to readme and migration post

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ gatsby develop
 ```
 
 Marquez green:
-RGB: 113-221-191
-CMYK: 49-0-14-13
+RGB: 113-221-191\
+CMYK: 49-0-14-13\
 HEX: #71DDBF
 
-Blog image: 600 x 245
+Blog image: 600 x 245\
 Blog banner: 770 x 125

--- a/contents/blog/version-30-upgrades/index.mdx
+++ b/contents/blog/version-30-upgrades/index.mdx
@@ -54,16 +54,16 @@ To perform a migration, these users must run the following command:
 java -jar api/build/libs/marquez-api-0.30.0.jar db-migrate --version v57 ./marquez.yml
 ```
 
-Available command arguments, `version` and `chunkSize`, allow the user to specify 
-the migration version to apply and the number of lineage events to process. 
-The command will process the data not in its entirety but in chunks, storing a 
-state with information about the chunks being processed. Consequently,
+Available command arguments, `version` (required) and `chunkSize` (optional), 
+allow the user to specify the migration version to apply and the number of 
+lineage events to process (the default being 10,000). The command will process 
+the data not in its entirety but in chunks, storing a state with information 
+about the chunks being processed. Consequently,
 
 - it can be stopped any time
 - it will continue automatically and process the remaining chunks. 
 
-The default chunk size, 10,000, refers to the number of `lineage_events` 
-processed in a single query. The chunk size may be adjusted via command parameter:
+A sample command specifying version 57 and 50,000 events:
 
 ```
 java -jar api/build/libs/marquez-api-0.30.0.jar db-migrate --version v57 --chunkSize 50000 ./marquez.yml


### PR DESCRIPTION
Edits to the README and migration post would improve readability and cut down on needless repetition.