### PR TITLE
update slack links and use invite

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -52,7 +52,7 @@ const siteMetadata = {
         },
         {
             name: "Slack",
-            url: "https://bit.ly/MarquezSlack",
+            url: "https://bit.ly/MqzSlack",
             rel: "",
         },
         {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -77,7 +77,7 @@ const Wall = ({ data }) => {
                     />
                     <Button
                         title="Slack"
-                        to='http://bit.ly/MarquezSlack'
+                        to='https://bit.ly/MqzSlackInvite'
                         type="extbutton"
                         iconRight={<Slack />}
                         className="mx-5 rounded-full opacity-80 hover:opacity-100 transition duration-500 ease-in-out transform hover:scale-105"


### PR DESCRIPTION
The website's Slack links don't include an invite link. This updates the links and makes one of them an invite link.

Closes: https://github.com/MarquezProject/marquez/issues/2533